### PR TITLE
Add browser-based task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Task Manager App
 
 This simple command-line app now supports binary attachments for tasks.
+
+A lightweight HTML interface has been added (see `index.html`, `style.css` and `script.js`).
+It stores tasks in the browser using `localStorage`, so you can copy the files into
+CodePen or any static host and manage tasks in the browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Administrador de Tareas</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Administrador de Tareas</h1>
+        <form id="taskForm">
+            <div class="form-group">
+                <label for="title">Título:</label>
+                <input type="text" id="title" required>
+            </div>
+            <div class="form-group">
+                <label for="description">Descripción:</label>
+                <textarea id="description" required></textarea>
+            </div>
+            <div class="form-group">
+                <label for="attachment">Adjunto (opcional):</label>
+                <input type="file" id="attachment" accept="*/*">
+            </div>
+            <button type="submit">Agregar Tarea</button>
+        </form>
+        <ul id="taskList"></ul>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,49 @@
+// Utiliza localStorage para persistir las tareas
+function loadTasks() {
+    const data = localStorage.getItem('tasks');
+    return data ? JSON.parse(data) : [];
+}
+
+function saveTasks(tasks) {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function renderTasks() {
+    const tasks = loadTasks();
+    const list = document.getElementById('taskList');
+    list.innerHTML = '';
+    tasks.forEach((t, i) => {
+        const li = document.createElement('li');
+        li.textContent = `${i + 1}. ${t.title} - ${t.description}`;
+        if (t.attachment) {
+            const span = document.createElement('span');
+            span.className = 'attachment';
+            span.textContent = ' [adjunto]';
+            li.appendChild(span);
+        }
+        list.appendChild(li);
+    });
+}
+
+async function handleAdd(e) {
+    e.preventDefault();
+    const title = document.getElementById('title').value.trim();
+    const description = document.getElementById('description').value.trim();
+    const fileInput = document.getElementById('attachment');
+    let attachment = null;
+
+    if (fileInput.files.length > 0) {
+        const file = fileInput.files[0];
+        const data = await file.arrayBuffer();
+        attachment = btoa(String.fromCharCode(...new Uint8Array(data)));
+    }
+
+    const tasks = loadTasks();
+    tasks.push({ title, description, attachment });
+    saveTasks(tasks);
+    e.target.reset();
+    renderTasks();
+}
+
+document.getElementById('taskForm').addEventListener('submit', handleAdd);
+document.addEventListener('DOMContentLoaded', renderTasks);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    padding: 20px;
+}
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+form {
+    margin-bottom: 20px;
+}
+.form-group {
+    margin-bottom: 10px;
+}
+label {
+    display: block;
+    margin-bottom: 4px;
+}
+input[type="text"], textarea {
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+}
+button {
+    padding: 8px 12px;
+}
+ul {
+    list-style: none;
+    padding: 0;
+}
+li {
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+}
+.attachment {
+    color: green;
+    font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- add `index.html`, `style.css` and `script.js` to provide a simple web UI
- update README with instructions on using the HTML interface

## Testing
- `python -m py_compile task_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6849054abe48832a88cf95dec2c3d28d