### PR TITLE
Add task completion and recurrent tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The interface has three tabs for organising tasks:
 
 * **Importantes**
 * **Diarias**
-* **Anuales**
+* **Recurrentes**
 
-Each task lets you set a start and end date and an optional attachment. Use the
-tabs to switch between categories and view only the tasks for that section.
+Each task lets you set a start and end date and an optional attachment. In the
+"Recurrentes" tab you can also specify a frequency such as mensual or semanal.
+Use the tabs to switch between categories and view only the tasks for that
+section. Tasks can be marcadas como completadas mediante una casilla de
+verificación y se muestran en verde cuando están listas. Un botón permite
+eliminar todas las tareas completadas.

--- a/index.html
+++ b/index.html
@@ -12,9 +12,13 @@
         <div class="tabs">
             <button data-category="importante" class="tab active">Importantes</button>
             <button data-category="diaria" class="tab">Diarias</button>
-            <button data-category="anual" class="tab">Anuales</button>
+            <button data-category="recurrente" class="tab">Recurrentes</button>
         </div>
-        <form id="taskForm">
+        <div class="actions">
+            <button id="showFormBtn" class="add-btn">Agregar tarea +</button>
+            <button id="deleteDoneBtn" class="delete-btn">Eliminar tareas hechas</button>
+        </div>
+        <form id="taskForm" style="display:none;">
             <div class="form-group">
                 <label for="title">Título:</label>
                 <input type="text" id="title" required>
@@ -30,6 +34,15 @@
             <div class="form-group">
                 <label for="endDate">Hasta:</label>
                 <input type="date" id="endDate" required>
+            </div>
+            <div class="form-group" id="freqGroup" style="display:none;">
+                <label for="frequency">Frecuencia:</label>
+                <select id="frequency">
+                    <option value="diaria">Diaria</option>
+                    <option value="semanal">Semanal</option>
+                    <option value="mensual">Mensual</option>
+                    <option value="anual">Anual</option>
+                </select>
             </div>
             <div class="form-group">
                 <label for="attachment">Adjunto (opcional):</label>

--- a/script.js
+++ b/script.js
@@ -10,18 +10,51 @@ function saveTasks(tasks) {
 
 let currentCategory = 'importante';
 
+document.getElementById('showFormBtn').addEventListener('click', () => {
+    const form = document.getElementById('taskForm');
+    form.style.display = form.style.display === 'none' ? 'block' : 'none';
+});
+
+document.getElementById('deleteDoneBtn').addEventListener('click', deleteDone);
+
 function renderTasks() {
     const tasks = loadTasks();
     const list = document.getElementById('taskList');
     list.innerHTML = '';
-    tasks.filter(t => t.category === currentCategory).forEach((t, i) => {
+    tasks.forEach((t, i) => {
+        if (t.category !== currentCategory) return;
         const li = document.createElement('li');
-        li.textContent = `${i + 1}. ${t.title} (${t.startDate} - ${t.endDate}) - ${t.description}`;
+        li.className = 'task';
+        if (t.done) li.classList.add('done');
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = !!t.done;
+        checkbox.addEventListener('change', () => {
+            const all = loadTasks();
+            all[i].done = checkbox.checked;
+            saveTasks(all);
+            renderTasks();
+        });
+        li.appendChild(checkbox);
+
+        const span = document.createElement('span');
+        let text = `${t.title}`;
+        if (t.startDate || t.endDate) {
+            text += ` (${t.startDate || ''} - ${t.endDate || ''})`;
+        }
+        text += ` - ${t.description}`;
+        if (t.frequency) {
+            text += ` [${t.frequency}]`;
+        }
+        span.textContent = text;
+        li.appendChild(span);
+
         if (t.attachment) {
-            const span = document.createElement('span');
-            span.className = 'attachment';
-            span.textContent = ' [adjunto]';
-            li.appendChild(span);
+            const att = document.createElement('span');
+            att.className = 'attachment';
+            att.textContent = ' [adjunto]';
+            li.appendChild(att);
         }
         list.appendChild(li);
     });
@@ -33,6 +66,7 @@ async function handleAdd(e) {
     const description = document.getElementById('description').value.trim();
     const startDate = document.getElementById('startDate').value;
     const endDate = document.getElementById('endDate').value;
+    const frequency = document.getElementById('frequency').value;
     const fileInput = document.getElementById('attachment');
     let attachment = null;
 
@@ -43,7 +77,7 @@ async function handleAdd(e) {
     }
 
     const tasks = loadTasks();
-    tasks.push({ title, description, startDate, endDate, category: currentCategory, attachment });
+    tasks.push({ title, description, startDate, endDate, category: currentCategory, attachment, frequency: currentCategory === 'recurrente' ? frequency : undefined, done: false });
     saveTasks(tasks);
     e.target.reset();
     renderTasks();
@@ -62,5 +96,26 @@ function switchCategory(cat) {
     document.querySelectorAll('.tab').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.category === cat);
     });
+    const form = document.getElementById('taskForm');
+    form.style.display = 'none';
+    const freqGroup = document.getElementById('freqGroup');
+    const start = document.getElementById('startDate');
+    const end = document.getElementById('endDate');
+    if (cat === 'recurrente') {
+        freqGroup.style.display = 'block';
+        start.required = false;
+        end.required = false;
+    } else {
+        freqGroup.style.display = 'none';
+        start.required = true;
+        end.required = true;
+    }
+    renderTasks();
+}
+
+function deleteDone() {
+    let tasks = loadTasks();
+    tasks = tasks.filter(t => !t.done);
+    saveTasks(tasks);
     renderTasks();
 }

--- a/style.css
+++ b/style.css
@@ -31,6 +31,14 @@ button {
     padding: 8px 12px;
 }
 
+.actions {
+    margin-bottom: 15px;
+}
+
+.add-btn {
+    margin-right: 10px;
+}
+
 .tabs {
     display: flex;
     margin-bottom: 15px;
@@ -57,9 +65,16 @@ ul {
     list-style: none;
     padding: 0;
 }
-li {
+li.task {
+    display: flex;
+    align-items: center;
     padding: 8px;
     border-bottom: 1px solid #ddd;
+    transition: background 0.3s;
+}
+
+.task.done {
+    background: #d1f0d1;
 }
 .attachment {
     color: green;


### PR DESCRIPTION
## Summary
- rename Anuales category to Recurrentes and show frequency field
- add buttons to toggle task form and delete completed tasks
- show tasks with checkbox to mark as done and highlight in green
- allow deleting all completed tasks
- document new recurrent category and completion features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849092db104832aafcbceb693d29c93